### PR TITLE
Fix separator parsing

### DIFF
--- a/src/FileParser.php
+++ b/src/FileParser.php
@@ -93,7 +93,7 @@ class FileParser
      */
     protected function getHeader ($text) {
         $separator = $this->config['separator'];
-        $parts = explode("\n$separator\n", $text);
+        $parts = explode("\n$separator", $text);
         return $parts[0];
     }
 
@@ -241,7 +241,7 @@ class FileParser
 
     protected function getBody ($text) {
         $separator = $this->config['separator'];
-        $parts = explode("\n$separator\n", $text);
-        return $parts[1];
+        $parts = explode("\n$separator", $text);
+        return trim($parts[1]);
     }
 }


### PR DESCRIPTION
Randomly started getting this:

```
[2017-05-15 22:17:48] local.ERROR: Skyronic\FileGenerator\FileGeneratorException: JSON Exception: [css] Syntax error in /home/vagrant/Projects/Uproar/vendor/skyronic/laravel-file-generator/src/FileParser.php:84
Stack trace:
#0 /home/vagrant/Projects/Uproar/vendor/skyronic/laravel-file-generator/src/FileParser.php(71): Skyronic\FileGenerator\FileParser->getMeta('{\r\n   "name": "...')
#1 /home/vagrant/Projects/Uproar/vendor/skyronic/laravel-file-generator/src/FileParser.php(61): Skyronic\FileGenerator\FileParser->firstPassParse()
#2 /home/vagrant/Projects/Uproar/vendor/skyronic/laravel-file-generator/src/FileList.php(60): Skyronic\FileGenerator\FileParser->readFile(Object(Symfony\Component\Finder\SplFileInfo))
#3 /home/vagrant/Projects/Uproar/vendor/skyronic/laravel-file-generator/src/FileGenListCommand.php(23): Skyronic\FileGenerator\FileList->readDirectory('/home/vagrant/P...')
#4 [internal function]: Skyronic\FileGenerator\FileGenListCommand->handle()
#5 /home/vagrant/Projects/Uproar/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(29): call_user_func_array(Array, Array)
#6 /home/vagrant/Projects/Uproar/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(87): Illuminate\Container\BoundMethod::Illuminate\Container\{closure}()
#7 /home/vagrant/Projects/Uproar/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php(31): Illuminate\Container\BoundMethod::callBoundMethod(Object(Illuminate\Foundation\Application), Array, Object(Closure))
#8 /home/vagrant/Projects/Uproar/vendor/laravel/framework/src/Illuminate/Container/Container.php(531): Illuminate\Container\BoundMethod::call(Object(Illuminate\Foundation\Application), Array, Array, NULL)
#9 /home/vagrant/Projects/Uproar/vendor/laravel/framework/src/Illuminate/Console/Command.php(182): Illuminate\Container\Container->call(Array)
#10 /home/vagrant/Projects/Uproar/vendor/symfony/console/Command/Command.php(264): Illuminate\Console\Command->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#11 /home/vagrant/Projects/Uproar/vendor/laravel/framework/src/Illuminate/Console/Command.php(167): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Illuminate\Console\OutputStyle))
#12 /home/vagrant/Projects/Uproar/vendor/symfony/console/Application.php(835): Illuminate\Console\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /home/vagrant/Projects/Uproar/vendor/symfony/console/Application.php(200): Symfony\Component\Console\Application->doRunCommand(Object(Skyronic\FileGenerator\FileGenListCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /home/vagrant/Projects/Uproar/vendor/symfony/console/Application.php(124): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /home/vagrant/Projects/Uproar/vendor/laravel/framework/src/Illuminate/Foundation/Console/Kernel.php(122): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#16 /home/vagrant/Projects/Uproar/artisan(35): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#17 {main}
```

This fixes the issue for me, no idea if it'd cause anything else to break.