### PR TITLE
Fix separator issue with windows.

### DIFF
--- a/src/FileParser.php
+++ b/src/FileParser.php
@@ -93,7 +93,7 @@ class FileParser
      */
     protected function getHeader ($text) {
         $separator = $this->config['separator'];
-        $parts = explode("\n$separator\n", $text);
+        $parts = preg_split("/[\r\n|\r|\n]".$separator."[\r\n|\r|\n]/", $text);
         return $parts[0];
     }
 


### PR DESCRIPTION
Fix separator issue with windows.
the line ending in windows is \r\n and mac \n