### PR TITLE
Code Compatibility Issue on Windows: Update explode() with preg_split() for Line Separators

### DIFF
--- a/src/FileParser.php
+++ b/src/FileParser.php
@@ -241,7 +241,7 @@ class FileParser
 
     protected function getBody ($text) {
         $separator = $this->config['separator'];
-        $parts = explode("\n$separator\n", $text);
+        $parts = preg_split("/[\r\n|\r|\n]".$separator."[\r\n|\r|\n]/", $text);
         return $parts[1];
     }
 }


### PR DESCRIPTION
# Description:
The existing code snippet $parts = explode("\n$separator\n", $text); encounters compatibility issues on Windows platforms. To ensure cross-platform functionality, I propose updating the code to use preg_split() with a regular expression pattern.

# Steps to Reproduce:
1. Execute the current code on a Windows machine.
2. Observe that the code fails to split the string properly.

# Expected Behavior:
The code should work consistently on both Windows and other operating systems.

# Proposed Solution:
Replace the problematic line with the following code snippet:

```php
$parts = preg_split("/[\r\n|\r|\n]".$separator."[\r\n|\r|\n]/", $text);
```

# Context:
The explode() function is unable to handle different line separators on Windows, leading to unexpected results. By utilizing preg_split() with a regular expression pattern, we can account for various line separator combinations, ensuring compatibility across different platforms.

# Additional Information:
1. Line separators vary across different operating systems:
- Mac: `\r`
- Linux/Unix: `\n`
- Windows: `\r\n`
